### PR TITLE
Fixed "git-scm.org" website url

### DIFF
--- a/content/chapter0/0.1-chinese.md
+++ b/content/chapter0/0.1-chinese.md
@@ -4,11 +4,11 @@
 
 为了测试源码，需要使用Git获取代码：
 
-* 主要的GNU/Linux发行版都可以通过包管理器安装Git。也可以从Git项目网站 https://gitscm.com 下载二进制发行版，进行安装。
+* 主要的GNU/Linux发行版都可以通过包管理器安装Git。也可以从Git项目网站 https://git-scm.com 下载二进制发行版，进行安装。
 * MacOS上，可以使用自制或MacPorts安装Git。
-* Windows上，可以从git项目网站( https://git-scm.com )下载git可执行安装文件。
+* Windows上，可以从Git项目网站( https://git-scm.com )下载Git可执行安装文件。
 
-可以通过github桌面客户端访问这些示例，网址为 https://desktop.github.com 。
+可以通过GitHub桌面客户端访问这些示例，网址为 https://desktop.github.com 。
 
 另一种选择是从 https://github.com/dev-cafe/cmake-cookbook 下载zip文件。
 
@@ -28,4 +28,4 @@ $ git clone https://github.com/dev-cafe/cmake-cookbook.git
 $ git clone --single-branch -b v1.0 https://github.com/dev-cafe/cmake-cookbook.git
 ```
 
-我们希望收到Bug修复，并且Github库将继续发展。要获取更新，可以选择库的master分支。
+我们希望收到Bug修复，并且GitHub库将继续发展。要获取更新，可以选择库的master分支。


### PR DESCRIPTION
gitscm.org -> gicscm.org

Also changed git to Git, github to GitHub to keep consistent.